### PR TITLE
Added import math

### DIFF
--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -30,6 +30,7 @@
 """
 import busio
 import digitalio
+import math
 import time
 
 class DotStar:


### PR DESCRIPTION
`math.ceil` is used in the library but `import math` was not included.