### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,12 +21,12 @@ Colors are stored as tuples by default. However, you can also use int hex syntax
 to set values similar to colors on the web. For example, ``0x100000`` (``#100000``
 on the web) is equivalent to ``(0x10, 0, 0)``.
 
+If you send a tuple with 4 values, you can control the brightness value, which appears in DotStar but not NeoPixels.
+It should be a float. For example, (0xFF,0,0, 1.0) is the brightest red possible, (1,0,0,0.01) is the dimmest red possible.
+
 .. note:: The int hex API represents the brightness of the white pixel when
   present by setting the RGB channels to identical values. For example, full
-  white is 0xffffff but is actually (0, 0, 0, 0xff) in the tuple syntax. Setting
-  a pixel value with an int will use the white pixel if the RGB channels are
-  identical. For full, independent, control of each color component use the
-  tuple syntax.
+  white is 0xffffff but is actually (0xff, 0xff, 0xff) in the tuple syntax. 
 
 Dependencies
 =============


### PR DESCRIPTION
Some doc changes to discuss the brightness bit, plus clear up some confusing wording. The documentation sounds like this library can control RGBW leds, but I don't think it can. 