### PR TITLE
Memoize scalar brightness calculations

### DIFF
--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -224,9 +224,11 @@ class DotStar:
         self._brightness = min(max(brightness, 0.0), 1.0)
 
         # We got a new global brightness, update all pixels in _buf
-        for index, val in enumerate(self._truebuf):
-            offset = index * (4 / 3) + START_HEADER_SIZE
-            self._buf[offset] = int(val * self._brightness)
+        truebuf_idx = 0
+        for i in range(START_HEADER_SIZE, self.end_header_index):
+            if i % 4 != 0:
+                self._buf[i] = self._truebuf[truebuf_idx] * self._brightness
+                truebuf_idx += 1
 
         if self.auto_write:
             self.show()

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -108,6 +108,7 @@ class DotStar:
         # 0xff bytes at the end.
         for i in range(self.end_header_index, len(self._buf)):
             self._buf[i] = 0xff
+        self._truebuf = [(255,255,255) for _ in range(n)]
         self._brightness = 1.0
         # Set auto_write to False temporarily so brightness setter does _not_
         # call show() while in __init__.
@@ -168,6 +169,7 @@ class DotStar:
         # LED startframe is three "1" bits, followed by 5 brightness bits
         # then 8 bits for each of R, G, and B. The order of those 3 are configurable and
         # vary based on hardware
+        self._truebuf = rgb
         if self.brightness < 1.0:
             rgb = [int(val * self._brightness) for val in rgb]
 
@@ -218,19 +220,16 @@ class DotStar:
 
     @brightness.setter
     def brightness(self, brightness):
-        brightness = min(max(brightness, 0.0), 1.0)
-        # scaling factor - new brightness / old.
-        # ex: going from 0.2 to 1 would be 1/0.2, so 5.0 * each color value
-        correction_factor = brightness / self.brightness
-        self._brightness = brightness
+        self._brightness = min(max(brightness, 0.0), 1.0)
 
-        if correction_factor != 1.0:
-            # We got a new global brightness, update all pixels in _buf
-            for i in range(START_HEADER_SIZE, self.end_header_index):
-                # only color values, not headers
-                if i % 4 != 0:
-                    new_val = int(self._buf[i] * correction_factor)
-                    self._buf[i] = min(max(new_val, 0), 255)
+        # We got a new global brightness, update all pixels in _buf
+        for index, rgb in enumerate(self._truebuf):
+            offset = index * 4 + START_HEADER_SIZE
+            rgb = [int(val * self._brightness) for val in rgb]
+
+            self._buf[offset + 1] = rgb[self.pixel_order[0]]
+            self._buf[offset + 2] = rgb[self.pixel_order[1]]
+            self._buf[offset + 3] = rgb[self.pixel_order[2]]
 
         if self.auto_write:
             self.show()

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -169,7 +169,7 @@ class DotStar:
         # LED startframe is three "1" bits, followed by 5 brightness bits
         # then 8 bits for each of R, G, and B. The order of those 3 are configurable and
         # vary based on hardware
-        self._truebuf = rgb
+        self._truebuf[index] = rgb
         if self.brightness < 1.0:
             rgb = [int(val * self._brightness) for val in rgb]
 

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -229,7 +229,8 @@ class DotStar:
             for i in range(START_HEADER_SIZE, self.end_header_index):
                 # only color values, not headers
                 if i % 4 != 0:
-                    self._buf[i] = int(self._buf[i] * correction_factor)
+                    new_val = int(self._buf[i] * correction_factor)
+                    self._buf[i] = min(max(new_val, 0), 255)
 
         if self.auto_write:
             self.show()

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -220,7 +220,7 @@ class DotStar:
     def brightness(self, brightness):
         brightness = min(max(brightness, 0.0), 1.0)
         # scaling factor - new brightness / old.
-        # ex: going from 0.2 to 1 would be 1/0.2 = 5.0 scale for each color val
+        # ex: going from 0.2 to 1 would be 1/0.2, so 5.0 * each color value
         correction_factor = brightness / self.brightness
         self._brightness = brightness
 

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -77,9 +77,9 @@ class DotStar:
             pixels[0] = RED
             time.sleep(2)
     """
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, clock, data, n, *, brightness=1.0, auto_write=True, pixel_order=BGR):
-        # pylint: disable=too-many-instance-attributes
         self._spi = None
         try:
             self._spi = busio.SPI(clock, MOSI=data)

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -171,7 +171,6 @@ class DotStar:
         if self.brightness < 1.0:
             rgb = [int(val * self._brightness) for val in rgb]
 
-
         brightness_byte = math.ceil(brightness * 31) & 0b00011111
         self._buf[offset] = brightness_byte | LED_START
         self._buf[offset + 1] = rgb[self.pixel_order[0]]
@@ -220,9 +219,10 @@ class DotStar:
     @brightness.setter
     def brightness(self, brightness):
         brightness = min(max(brightness, 0.0), 1.0)
-        old_brightness = self.brightness
+        # scaling factor - new brightness / old.
+        # ex: going from 0.2 to 1 would be 1/0.2 = 5.0 scale for each color val
+        correction_factor = brightness / self.brightness
         self._brightness = brightness
-        correction_factor = brightness/old_brightness
 
         if correction_factor != 1.0:
             # We got a new global brightness, update all pixels in _buf

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -79,6 +79,7 @@ class DotStar:
     """
 
     def __init__(self, clock, data, n, *, brightness=1.0, auto_write=True, pixel_order=BGR):
+        # pylint: disable=too-many-instance-attributes
         self._spi = None
         try:
             self._spi = busio.SPI(clock, MOSI=data)


### PR DESCRIPTION
@tannewt mentioned that the double buffer use for global brightness != 1 lead to a slight slowdown, so I memoized it. 

The way this works is we scale all pixels by global brightness when we insert them into the buffer, and then in `show()` we just flush the buffer.   We still need two buffers, one to store the scaled values and one to store the true buffers. 

Now, people may still want to update the global brightness and have the strip *flash* without resetting all the pixel values.  So, in the brightness setter, I scale all the brightness values by the the new brightness value, using the 'true buffer' as the source of truth for the intended color.

This should uses the same amount of memory as before - both required two buffers. But with this,  we save rebuilding the entire buffer on every single `show()` call, which feels like a significant win for folk who want a high refresh rate. 

## Testing:
~~Tested on hardware~~
(Needs fresh testing on hardware since latest changes)