### PR TITLE
catch NotImplementedError when using bitbanged pins

### DIFF
--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -83,7 +83,8 @@ class DotStar:
             while not self._spi.try_lock():
                 pass
             self._spi.configure(baudrate=4000000)
-        except ValueError:
+
+        except (NotImplementedError, ValueError) as e:
             self.dpin = digitalio.DigitalInOut(data)
             self.cpin = digitalio.DigitalInOut(clock)
             self.dpin.direction = digitalio.Direction.OUTPUT

--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -84,7 +84,7 @@ class DotStar:
                 pass
             self._spi.configure(baudrate=4000000)
 
-        except (NotImplementedError, ValueError) as e:
+        except (NotImplementedError, ValueError):
             self.dpin = digitalio.DigitalInOut(data)
             self.cpin = digitalio.DigitalInOut(clock)
             self.dpin.direction = digitalio.Direction.OUTPUT


### PR DESCRIPTION
On the Pi / CPython, I'm getting `NotImplementedError` here rather than `ValueError`:

```
(.env) pi@raspberrypi:~/Adafruit_CircuitPython_DotStar/examples $ python3 dotstar_simpletest.py 
Traceback (most recent call last):
  File "dotstar_simpletest.py", line 9, in <module>
    dots = dotstar.DotStar(board.D5, board.D6, 1, brightness=0.2)
  File "/home/pi/Adafruit_CircuitPython_DotStar/.env/lib/python3.5/site-packages/adafruit_dotstar.py", line 82, in __init__
    self._spi = busio.SPI(clock, MOSI=data)
  File "/home/pi/Adafruit_CircuitPython_DotStar/.env/lib/python3.5/site-packages/busio.py", line 88, in __init__
    format((clock, MOSI, MISO), spiPorts))
NotImplementedError: No Hardware SPI on (SCLK, MOSI, MISO)=(5, 6, None)
Valid SPI ports:((0, 11, 10, 9), (1, 21, 20, 19))
```

This pull makes the assumption that catching the `ValueError` is still necessary on CircuitPython.