### PR TITLE
Update to use adafruit_pixelbuf.

### DIFF
--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -17,9 +17,12 @@ import busio
 import digitalio
 
 try:
-    import _pixelbuf
+    import adafruit_pixelbuf
 except ImportError:
-    import adafruit_pypixelbuf as _pixelbuf
+    try:
+        import _pixelbuf as adafruit_pixelbuf
+    except ImportError:
+        import adafruit_pypixelbuf as adafruit_pixelbuf
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DotStar.git"
@@ -41,7 +44,7 @@ BGR = "PBGR"
 """Blue Green Red"""
 
 
-class DotStar(_pixelbuf.PixelBuf):
+class DotStar(adafruit_pixelbuf.PixelBuf):
     """
     A sequence of dotstars.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
-adafruit-circuitpython-pypixelbuf>=2.0.0
+adafruit-circuitpython-pixelbuf

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         "Adafruit-Blinka",
         "adafruit-circuitpython-busdevice",
-        "adafruit-circuitpython-pypixelbuf>=2.0.0",
+        "adafruit-circuitpython-pixelbuf",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
https://github.com/adafruit/circuitpython/pull/5010 renames `_pixelbuf` to `adafruit_pixelbuf`.

Maintains backwards compatibility until such time that we are ready to remove it.