### PR TITLE
zero bits for trailer

### DIFF
--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -127,8 +127,10 @@ class DotStar(adafruit_pixelbuf.PixelBuf):
 
         # Four empty bytes for the header.
         header = bytearray(START_HEADER_SIZE)
-        # 0xff bytes for the trailer.
-        trailer = bytearray(b"\xff") * trailer_size
+        # Zero bits, not ones, for the trailer, to avoid lighting up
+        # downstream pixels, if there are more physical pixels than
+        # the length of this object.
+        trailer = bytearray(trailer_size)
 
         super().__init__(
             n,


### PR DESCRIPTION
Use zero bits, not ones, for the trailer, to avoid lighting up downstream pixels when the DotStar object is created with fewer pixels than are physically present in the chian.

This is visible after the second update of a DotStar object that is at least 17 pixels long, when there is a greater number of physical pixels in the chain.
