### PR TITLE
adafruit_bus_device is not a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@
 
 Adafruit-Blinka>=7.0.0
 adafruit-circuitpython-typing
-adafruit-circuitpython-busdevice
 adafruit-circuitpython-pixelbuf


### PR DESCRIPTION
The bus device library is not a dependency for dotstar, it should not be installed by circup or included by the bundler.