### PR TITLE
Unlock SPI before deinit

### DIFF
--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -146,6 +146,7 @@ class DotStar(adafruit_pixelbuf.PixelBuf):
         self.fill(0)
         self.show()
         if self._spi:
+            self._spi.unlock()
             self._spi.deinit()
         else:
             self.dpin.deinit()


### PR DESCRIPTION
See https://github.com/adafruit/circuitpython/issues/9586. As of https://github.com/adafruit/circuitpython/pull/9164, on Espressif, `SPI.deinit()` waits for the SPI lock to be unlocked before doing the deinit. This causes `DotStar.deinit()` to hang. The  `DotStar` object has exclusive access to the `SPI` it creates and does not bother to lock and unlock it each time.

So just unlock the SPI lock before doing the `deinit()`. This may become unnecessary when https://github.com/adafruit/circuitpython/issues/9586 is addressed, but it's safer anyway.