### PR TITLE
lock SPI only when writing

### DIFF
--- a/adafruit_dotstar.py
+++ b/adafruit_dotstar.py
@@ -108,9 +108,9 @@ class DotStar(adafruit_pixelbuf.PixelBuf):
         self._spi = None
         try:
             self._spi = busio.SPI(clock, MOSI=data)
-            while not self._spi.try_lock():
-                pass
+            self._spi.try_lock()
             self._spi.configure(baudrate=baudrate)
+            self._spi.unlock()
 
         except (NotImplementedError, ValueError):
             self.dpin = digitalio.DigitalInOut(data)
@@ -145,7 +145,6 @@ class DotStar(adafruit_pixelbuf.PixelBuf):
         self.fill(0)
         self.show()
         if self._spi:
-            self._spi.unlock()
             self._spi.deinit()
         else:
             self.dpin.deinit()
@@ -174,7 +173,9 @@ class DotStar(adafruit_pixelbuf.PixelBuf):
 
     def _transmit(self, buffer: ReadableBuffer) -> None:
         if self._spi:
+            self._spi.try_lock()
             self._spi.write(buffer)
+            self._spi.unlock()
         else:
             self._ds_writebytes(buffer)
 


### PR DESCRIPTION
- Fixes #69.
- This also fixes https://github.com/adafruit/circuitpython/issues/10520, which was a crash caused by instatiating a `FunHouse()` object, and then trying to do some network activity.

Before this fix, the `DotStar` object grabbed the `SPI` lock forever. This is a problem on Espressif boards, which use a FreeRTOS mutex as the lock. See https://github.com/adafruit/circuitpython/issues/10561#issuecomment-3211752395 for details.

The fix is only to grab the `SPI` lock when actually writing. We could do this with `adafruit_bus_device`, but we don't need other aspects of that library, and we can save space just by doing the locking in the two places where it's needed.

There isn't a reason to test that `self._spi.try_lock()` succeeds or fails, since it should always succeed. The `SPI` object is not used by anyone else.

Tested on a FunHouse. It fixes the crash described in https://github.com/adafruit/circuitpython/issues/10520. I also tested to make sure the DotStars are still functional.